### PR TITLE
#1 - Show map by MapKit

### DIFF
--- a/running.io/ContentView.swift
+++ b/running.io/ContentView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import MapKit
 
 struct ContentView: View {
     var body: some View {
@@ -22,6 +23,26 @@ struct ContentView: View {
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
         ContentView()
+    }
+}
+
+struct FullScreenMapView: View {
+    @StateObject private var locationManager = LocationManager()
+    @State private var region = MKCoordinateRegion(
+        center: CLLocationCoordinate2D(latitude: 35.6895, longitude: 139.6917),
+        span: MKCoordinateSpan(latitudeDelta: 0.5, longitudeDelta: 0.5)
+    )
+
+    var body: some View {
+        Map(coordinateRegion: $region)
+            .edgesIgnoringSafeArea(.all)
+            .environmentObject(locationManager)
+    }
+}
+
+struct FullScreenMapView_Previews: PreviewProvider {
+    static var previews: some View {
+        FullScreenMapView()
     }
 }
 

--- a/running.io/LocationManager.swift
+++ b/running.io/LocationManager.swift
@@ -22,6 +22,8 @@ class LocationManager: NSObject, CLLocationManagerDelegate, ObservableObject {
         locationManager.startUpdatingLocation()
     }
     
+    
+    
     func locationManager(_ manager: CLLocationManager,
                          didUpdateLocations locations: [CLLocation]){
         

--- a/running.io/running_ioApp.swift
+++ b/running.io/running_ioApp.swift
@@ -9,11 +9,9 @@ import SwiftUI
 
 @main
 struct running_ioApp: App {
-    @StateObject private var locationManager = LocationManager()
     var body: some Scene {
         WindowGroup {
-            ContentView()
-                .environmentObject(locationManager)
+            FullScreenMapView()
         }
     }
 }


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: `ContentView.swift`に`FullScreenMapView`構造体が追加され、MapKitを使用して地図を表示するようになりました。ユーザーの位置を管理するための`locationManager`プロパティと、地図の初期領域を定義するための`region`プロパティが含まれています。`body`プロパティは指定された領域で地図ビューを設定し、セーフエリアを無視します。既存のコードには変更はありません。

- Refactor: `LocationManager.swift`にいくつかの余分な空行が削除されました。これにより、コードの可読性が向上しました。

- Refactor: `running_ioApp.swift`では、`ContentView`が削除され、代わりに`FullScreenMapView`が追加されました。また、`locationManager`の使用も削除されました。

このプルリクエストは、新機能の追加とコードのリファクタリングを含んでいます。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->